### PR TITLE
Update README, WiringPi deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,21 @@ To do so, open a terminal and execute `gpio -v`.
 
 If it's not installed, the easiest way is by calling `sudo apt install wiringpi`. If you need addidtional information or want to install from sources, check out [http://wiringpi.com/download-and-install/](http://wiringpi.com/download-and-install/). 
 
+NOTE: WiringPi is now deprecated and will not work out of the box on newer (≥Rpi4) boards, check out
+[http://wiringpi.com/wiringpi-deprecated/](http://wiringpi.com/wiringpi-deprecated/)
+
 ## USAGE
 You can include __pca9685.h__ and __pca9685.c__ directly in your project or compile it and include the lib file instead.
 	
 To compile, navigate into the src folder an run
-
-    sudo make install
-
+```console
+sudo make install
+```
 This will install pca9685 in your __/usr/lib__, __/usr/local/lib__ and __/usr/local/include__ directories.
 To include the files add the line
-
-    #include <pca9685.h>
-    
+```cpp
+#include <pca9685.h>
+```
 into your source code and include "__wiringPiPca9685__" in your linked files during compilation
 
 ## EXAMPLES
@@ -38,9 +41,9 @@ To run, add a "__./__" before each example and execute them, e.g. `./servo`.
 
 ## FUNCTIONS
 Use	
-
-    int pca9685Setup(const int pinBase, const int i2cAddress/* = 0x40*/, float freq/* = 50*/);
-
+```cpp
+int pca9685Setup(const int pinBase, const int i2cAddress/* = 0x40*/, float freq/* = 50*/);
+```
 to setup a single pca9685 device at the specified i2c address and PWM frequency.
 
 Parameters are:
@@ -62,32 +65,32 @@ NOTE: Don't forget to add the pin base!
 
 
 Set PWM
-
-	void pwmWrite (int pin, int value)
-	
+```cpp
+void pwmWrite (int pin, int value)
+```
 if value <= 0, set full-off
 else if value >= 4096, set full-on
 else set PWM
 
 Set full-on or full-off
-
-	void digitalWrite (int pin, int value)
-	
+```cpp
+void digitalWrite (int pin, int value)
+```
 if value != 0, set full-on
 else set full-off
 
 Read off-register
-
-	int digitalRead (int pin)
-	
+```cpp
+int digitalRead (int pin)
+```
 To get PWM: mask with 0xFFF
 To get full-off bit: mask with 0x1000
 Note: ALL_LED pin will always return 0
 
 Read on-register
-
-	int analogRead (int pin)
-	
+```cpp
+int analogRead (int pin)
+```
 To get PWM: mask with 0xFFF
 To get full-on bit: mask with 0x1000
 Note: ALL_LED pin will always return 0
@@ -96,9 +99,9 @@ Note: ALL_LED pin will always return 0
 
 NOTE: Unfortunately wiringPi doesn't offer suitable names for pca9685's functions, so we have to work with the provided ones. 
 Masking means to bitwise-AND (operator &) the return value with the mask. E.g. & 0xFFF
-
-	int offValue = digitalRead(pinBase + 0) & 0xFFF;
-	
+```cpp
+int offValue = digitalRead(pinBase + 0) & 0xFFF;
+```
 ## ADVANCED		
 
 If you don't want to use the wiringPi functions or want to access the pca9685
@@ -107,19 +110,20 @@ the following functions for each connected pca9685 individually.
 (View source code for more details)
 
 Set output frequency in a range between 40 and 1000 Hertz
-
-	void pca9685PWMFreq(int fd, float freq);
-	
+```cpp
+void pca9685PWMFreq(int fd, float freq);
+```
 Reset all PWM output of this device to default state which is full-off
-
-	void pca9685PWMReset(int fd);
-
+```cpp
+void pca9685PWMReset(int fd);
+```
 Write PWM on and off values to a specific pin. (View source code)
-
-    void pca9685PWMWrite(int fd, int pin, int on, int off);
-    void pca9685PWMRead(int fd, int pin, int *on, int *off);
-
+```cpp
+void pca9685PWMWrite(int fd, int pin, int on, int off);
+void pca9685PWMRead(int fd, int pin, int *on, int *off);
+```
 Write enable or disable full-on and full-off of a specific pin. (View source code)
-
-    void pca9685FullOn(int fd, int pin, int tf);
-    void pca9685FullOff(int fd, int pin, int tf);
+```cpp
+void pca9685FullOn(int fd, int pin, int tf);
+void pca9685FullOff(int fd, int pin, int tf);
+```


### PR DESCRIPTION
Update- README with a warning that, since August 6, 2019 WiringPi is not longer maintained, check out http://wiringpi.com/wiringpi-deprecated/
There is a unofficial mirror/fork to support newer hardware https://github.com/WiringPi/WiringPi
Add- Github flavored markdown syntax highlighting for code snippets